### PR TITLE
Fix the problem that new matplotlib.cm does not have get_cmap.

### DIFF
--- a/polychrom_hoomd/render.py
+++ b/polychrom_hoomd/render.py
@@ -1,7 +1,7 @@
 import numpy as np
-from polykit.renderers import backends, viewers
-
 import polychrom_hoomd.utils as utils
+
+from polykit.renderers import backends, viewers
 
 try:
     from matplotlib.cm import get_cmap

--- a/polychrom_hoomd/render.py
+++ b/polychrom_hoomd/render.py
@@ -1,53 +1,61 @@
 import numpy as np
-import polychrom_hoomd.utils as utils
-
 from polykit.renderers import backends, viewers
 
-from matplotlib.cm import get_cmap
+import polychrom_hoomd.utils as utils
+
+try:
+    from matplotlib.cm import get_cmap
+except ImportError:
+    from matplotlib import colormaps
 from matplotlib.colors import Normalize
 
 
-def domain_viewer(snap, cmap='coolwarm', **kwargs):
+def domain_viewer(snap, cmap="coolwarm", **kwargs):
     """
     Visualize chromatin domains per chromosome in 1D
     """
-        
+
     chrom_bounds = utils.get_chrom_bounds(snap)
     chrom_lengths = np.diff(chrom_bounds, axis=1).flatten() + 1
-        
+
     typeids = snap.particles.typeid.copy()
     vmin, vmax = typeids.min(), typeids.max()
-    
+
     number_of_monomers = sum(chrom_lengths)
-    colors = get_cmap(cmap)(Normalize(vmin=vmin, vmax=vmax)(typeids))
-    
-    colors[:, 3] = 1.
+    try:
+        colors = get_cmap(cmap)(Normalize(vmin=vmin, vmax=vmax)(typeids))
+    except NameError:
+        colors = colormaps[cmap](Normalize(vmin=vmin, vmax=vmax)(typeids))
+
+    colors[:, 3] = 1.0
     colors = colors[:number_of_monomers]
-    
+
     viewers.chromosome_viewer(chrom_lengths, colors, **kwargs)
 
 
-def fresnel(snap,
-            cmap='viridis',
-            rescale_backbone_bonds=1.,
-            show=None,
-            color_array=None,
-            **kwargs):
+def fresnel(
+    snap,
+    cmap="viridis",
+    rescale_backbone_bonds=1.0,
+    show=None,
+    color_array=None,
+    **kwargs,
+):
     """
     Wrapper around polykit.renderers.backends for HooMD rendering using the Fresnel library
     """
 
     bonds = snap.bonds.group.copy()
     positions = utils.unwrap_coordinates(snap)
-        
+
     bond_mask = np.ones(snap.particles.N, dtype=bool)
     polymer_mask = np.ones(snap.particles.N, dtype=bool)
 
-    LEF_typeid = snap.bonds.types.index('LEF') if 'LEF' in snap.bonds.types else -1
+    LEF_typeid = snap.bonds.types.index("LEF") if "LEF" in snap.bonds.types else -1
 
     polymer_mask[bonds] = False
     bond_mask[bonds[snap.bonds.typeid == LEF_typeid]] = False
-    
+
     bond_mask[polymer_mask] = False
 
     radii = snap.particles.diameter.copy() * 0.5
@@ -55,32 +63,35 @@ def fresnel(snap,
 
     if isinstance(color_array, np.ndarray):
         colorscale = color_array
-        
+
     else:
         colorscale = np.zeros(snap.particles.N)
-    
+
         if show == "chromosomes":
             chrom_bounds = utils.get_chrom_bounds(snap)
-                    
+
             for i, bounds in enumerate(chrom_bounds):
-                colorscale[bounds[0]:bounds[1]+1] = i+1
-                            
+                colorscale[bounds[0] : bounds[1] + 1] = i + 1
+
         elif show == "loops":
             loop_bounds = bonds[snap.bonds.typeid == LEF_typeid]
-                    
+
             for i, bounds in enumerate(loop_bounds):
-                colorscale[bounds[0]:bounds[1]+1] = i+1
-                        
+                colorscale[bounds[0] : bounds[1] + 1] = i + 1
+
         elif show == "compartments":
             colorscale = snap.particles.typeid.copy()
-            
+
         elif show == "strains":
             strains = np.diff(positions[bonds], axis=1)
             colorscale = np.linalg.norm(strains, axis=-1).flatten()
-            
+
         else:
             colorscale = np.arange(snap.particles.N)
-    
-    colors = get_cmap(cmap)(Normalize()(colorscale))
+
+    try:
+        colors = get_cmap(cmap)(Normalize()(colorscale))
+    except NameError:
+        colors = colormaps[cmap](Normalize()(colorscale))
 
     return backends.Fresnel(positions, bonds, colors, radii, **kwargs)

--- a/polychrom_hoomd/render.py
+++ b/polychrom_hoomd/render.py
@@ -10,52 +10,50 @@ except ImportError:
 from matplotlib.colors import Normalize
 
 
-def domain_viewer(snap, cmap="coolwarm", **kwargs):
+def domain_viewer(snap, cmap='coolwarm', **kwargs):
     """
     Visualize chromatin domains per chromosome in 1D
     """
-
+        
     chrom_bounds = utils.get_chrom_bounds(snap)
     chrom_lengths = np.diff(chrom_bounds, axis=1).flatten() + 1
-
+        
     typeids = snap.particles.typeid.copy()
     vmin, vmax = typeids.min(), typeids.max()
-
+    
     number_of_monomers = sum(chrom_lengths)
     try:
         colors = get_cmap(cmap)(Normalize(vmin=vmin, vmax=vmax)(typeids))
     except NameError:
         colors = colormaps[cmap](Normalize(vmin=vmin, vmax=vmax)(typeids))
-
-    colors[:, 3] = 1.0
+    
+    colors[:, 3] = 1.
     colors = colors[:number_of_monomers]
-
+    
     viewers.chromosome_viewer(chrom_lengths, colors, **kwargs)
 
 
-def fresnel(
-    snap,
-    cmap="viridis",
-    rescale_backbone_bonds=1.0,
-    show=None,
-    color_array=None,
-    **kwargs,
-):
+def fresnel(snap,
+            cmap='viridis',
+            rescale_backbone_bonds=1.,
+            show=None,
+            color_array=None,
+            **kwargs):
     """
     Wrapper around polykit.renderers.backends for HooMD rendering using the Fresnel library
     """
 
     bonds = snap.bonds.group.copy()
     positions = utils.unwrap_coordinates(snap)
-
+        
     bond_mask = np.ones(snap.particles.N, dtype=bool)
     polymer_mask = np.ones(snap.particles.N, dtype=bool)
 
-    LEF_typeid = snap.bonds.types.index("LEF") if "LEF" in snap.bonds.types else -1
+    LEF_typeid = snap.bonds.types.index('LEF') if 'LEF' in snap.bonds.types else -1
 
     polymer_mask[bonds] = False
     bond_mask[bonds[snap.bonds.typeid == LEF_typeid]] = False
-
+    
     bond_mask[polymer_mask] = False
 
     radii = snap.particles.diameter.copy() * 0.5
@@ -63,32 +61,32 @@ def fresnel(
 
     if isinstance(color_array, np.ndarray):
         colorscale = color_array
-
+        
     else:
         colorscale = np.zeros(snap.particles.N)
-
+    
         if show == "chromosomes":
             chrom_bounds = utils.get_chrom_bounds(snap)
-
+                    
             for i, bounds in enumerate(chrom_bounds):
-                colorscale[bounds[0] : bounds[1] + 1] = i + 1
-
+                colorscale[bounds[0]:bounds[1]+1] = i+1
+                            
         elif show == "loops":
             loop_bounds = bonds[snap.bonds.typeid == LEF_typeid]
-
+                    
             for i, bounds in enumerate(loop_bounds):
-                colorscale[bounds[0] : bounds[1] + 1] = i + 1
-
+                colorscale[bounds[0]:bounds[1]+1] = i+1
+                        
         elif show == "compartments":
             colorscale = snap.particles.typeid.copy()
-
+            
         elif show == "strains":
             strains = np.diff(positions[bonds], axis=1)
             colorscale = np.linalg.norm(strains, axis=-1).flatten()
-
+            
         else:
             colorscale = np.arange(snap.particles.N)
-
+    
     try:
         colors = get_cmap(cmap)(Normalize()(colorscale))
     except NameError:

--- a/polychrom_hoomd/render.py
+++ b/polychrom_hoomd/render.py
@@ -7,6 +7,7 @@ try:
     from matplotlib.cm import get_cmap
 except ImportError:
     from matplotlib import colormaps
+    get_cmap = lambda x:colormaps[x]
 from matplotlib.colors import Normalize
 
 
@@ -22,10 +23,7 @@ def domain_viewer(snap, cmap='coolwarm', **kwargs):
     vmin, vmax = typeids.min(), typeids.max()
     
     number_of_monomers = sum(chrom_lengths)
-    try:
-        colors = get_cmap(cmap)(Normalize(vmin=vmin, vmax=vmax)(typeids))
-    except NameError:
-        colors = colormaps[cmap](Normalize(vmin=vmin, vmax=vmax)(typeids))
+    colors = get_cmap(cmap)(Normalize(vmin=vmin, vmax=vmax)(typeids))
     
     colors[:, 3] = 1.
     colors = colors[:number_of_monomers]
@@ -87,9 +85,6 @@ def fresnel(snap,
         else:
             colorscale = np.arange(snap.particles.N)
     
-    try:
-        colors = get_cmap(cmap)(Normalize()(colorscale))
-    except NameError:
-        colors = colormaps[cmap](Normalize()(colorscale))
+    colors = get_cmap(cmap)(Normalize()(colorscale))
 
     return backends.Fresnel(positions, bonds, colors, radii, **kwargs)


### PR DESCRIPTION
In newer `matplotlib`, `matplotlib.cm import get_cmap` will fail in `render.py`. I fix this by `from matplotlib import colormaps` if an exception happens.
